### PR TITLE
Mystery page (link in navbar) updated with links to others webpages

### DIFF
--- a/application/src/main/resources/static/js/react-client/src/pages/fish/index.js
+++ b/application/src/main/resources/static/js/react-client/src/pages/fish/index.js
@@ -1,4 +1,12 @@
-import React, { useState } from 'react';
-
-import axios from 'axios';
+import React from 'react';
 import style from './style.module.scss';
+
+const Fish = () =>{
+
+    return (
+        <div className={style.fish}>
+            <a href='https://www.fishwatch.gov/api/species'></a>
+        </div>
+    );
+}
+export default Fish;

--- a/application/src/main/resources/static/js/react-client/src/pages/home-screen/index.js
+++ b/application/src/main/resources/static/js/react-client/src/pages/home-screen/index.js
@@ -11,33 +11,9 @@ import choiceImage1 from '../../assets/choice1.jpg';
 
 const Homepage = () => {
     return (
-        <div></div>
-        // <div className={style.container}>
-        //     <div className={style.section1}>
-        //         <h2>My space</h2>
-        //         <img src={spaceImage} alt='space image' /> 
-        //     </div>
-        //     <div className={style.section4}>
-        //         <h2>Explorer</h2>
-        //         <img src={spaceImage3} alt='space image' /> 
-        //     </div>
-        //     <div className={style.section5}>
-                
-        //         <h2>NASA</h2>
-        //         <img src={choiceImage} alt='finger image' /> 
-        //         <h4><em>Or</em></h4>
-        //         <h2>OCEAN TREASURES</h2>
-        //         <img src={choiceImage1} alt='finger image' /> 
-        //     </div>
-        //     <div className={style.section2}>
-        //         <h2>Type of fish</h2>
-        //         <img src={spaceImage1} alt='fish image' /> 
-        //     </div>
-        //     <div className={style.section3}>
-        //         <h2>Go fishing</h2>
-        //         <img src={spaceImage2} alt='fish image' /> 
-        //     </div>
-        //     </div>
+        <div>
+            
+        </div>
         
     );
 }

--- a/application/src/main/resources/static/js/react-client/src/pages/mystery-educator/index.js
+++ b/application/src/main/resources/static/js/react-client/src/pages/mystery-educator/index.js
@@ -16,11 +16,11 @@ const Mystery = () => {
             
             <div className={style.section1}>
                 <h2>My space</h2>
-                <img src={spaceImage} alt='space image' /> 
+                <a href='https://spaceplace.nasa.gov/menu/play/' target="_blank"><img src={spaceImage} alt='space image' /></a> 
             </div>
             <div className={style.section4}>
                 <h2>Explorer</h2>
-                <img src={spaceImage3} alt='space image' /> 
+                <a href='https://nasa.gov/' target="_blank"><img src={spaceImage3} alt='space image' /></a> 
             </div>
             <div className={style.section5}>
                 
@@ -32,11 +32,11 @@ const Mystery = () => {
             </div>
             <div className={style.section2}>
                 <h2>Type of fish</h2>
-                <img src={spaceImage1} alt='fish image' /> 
+                <a href='https://www.fishwatch.gov/' target="_blank"><img src={spaceImage1} alt='fish image' /></a>
             </div>
             <div className={style.section3}>
                 <h2>Go fishing</h2>
-                <img src={spaceImage2} alt='fish image' /> 
+                <a href='https://www.fishwatch.gov/profiles/southeast-profiles'><img src={spaceImage2} alt='fish image' /></a>
             </div>
             </div>
         </div>


### PR DESCRIPTION
I did add some links to each image on the mystery page. When you click on "Mystery" in the navbar, it takes you to a page that displays the images associated with each section (NASA or Fish), and when an image is clicked, it opens on a webpage. I might not have done it perfectly right, but it's the result I am looking for when we use the API stuff. 